### PR TITLE
Fix stdout logging issue causing Codex CLI registration to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm install
+      
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]

--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ function getComponentDocs(componentName) {
 
 function getSelectedComponentsDocs(componentNames) {
   const docsObject = {};
-  console.log(
+  console.error(
     `✅ Getting documentation for components: ${componentNames.join(", ")}`
   );
 
@@ -215,7 +215,7 @@ server.tool(
       .describe("The names of the components"),
   },
   (input) => {
-    console.log(
+    console.error(
       `✅ Selected components: ${input.selectedComponents.join(", ")}`
     );
 
@@ -247,7 +247,7 @@ server.tool(
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.log("Use Gluestack Components MCP Server running on stdio");
+  console.error("Use Gluestack Components MCP Server running on stdio");
 }
 
 main().catch((error) => {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/test/no-stdout-on-start.test.js
+++ b/test/no-stdout-on-start.test.js
@@ -1,0 +1,59 @@
+import { spawn } from "child_process";
+import { test } from "node:test";
+import assert from "node:assert";
+import { fileURLToPath } from "url";
+import path from "path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+test("MCP server should not write to stdout on startup", async () => {
+  const indexPath = path.join(__dirname, "..", "index.js");
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [indexPath], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdoutData = "";
+    let stderrData = "";
+
+    child.stdout.on("data", (data) => {
+      stdoutData += data.toString();
+    });
+
+    child.stderr.on("data", (data) => {
+      stderrData += data.toString();
+    });
+
+    // Wait 500ms then kill the process and check stdout
+    setTimeout(() => {
+      child.kill("SIGTERM");
+
+      // Allow time for process to clean up
+      setTimeout(() => {
+        try {
+          // Assert that stdout is empty (no plain text logging)
+          assert.strictEqual(
+            stdoutData.trim(),
+            "",
+            "stdout should be empty on startup - MCP protocol uses stdout for JSON-RPC messages only"
+          );
+
+          // Verify that stderr contains our log message (optional, but good to confirm logs are going somewhere)
+          assert.ok(
+            stderrData.includes("Use Gluestack Components MCP Server"),
+            "stderr should contain startup message"
+          );
+
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      }, 100);
+    }, 500);
+
+    child.on("error", (err) => {
+      reject(err);
+    });
+  });
+});

--- a/test/no-stdout-on-start.test.js
+++ b/test/no-stdout-on-start.test.js
@@ -41,8 +41,8 @@ test("MCP server should not write to stdout on startup", async () => {
 
           // Verify that stderr contains our log message (optional, but good to confirm logs are going somewhere)
           assert.ok(
-            stderrData.includes("Use Gluestack Components MCP Server"),
-            "stderr should contain startup message"
+            stderrData.includes("Gluestack") && stderrData.includes("MCP Server"),
+            "stderr should contain startup message with 'Gluestack' and 'MCP Server'"
           );
 
           resolve();


### PR DESCRIPTION
Fixes issue #5 

The MCP server wrote plain text to stdout, corrupting the JSON-RPC protocol stream and causing clients like MCP Inspector to fail on connect with parse errors.

### Changes

**Redirect logs from stdout to stderr**
- Changed 3 `console.log` calls to `console.error` in index.js:
  - Server startup message in `main()`
  - Component selection logging in `select_components` tool handler
  - Documentation retrieval logging in `getSelectedComponentsDocs()`

**Add regression test**
- Created `test/no-stdout-on-start.test.js` that spawns the server process and asserts stdout remains empty while stderr contains expected logs
- Updated package.json to run tests via `node --test`

**Add CI workflow**
- Created `.github/workflows/ci.yml` to run tests on Node 18.x, 20.x, 22.x
- Triggers on push to main and PRs targeting main
- Status check will be `CI / test` for branch protection rules

### Enabling Branch Protection

After merge, configure main branch to require `CI / test` status check to prevent future regressions.

<!-- START COPILOT CODING AGENT SUFFIX -->



<details>

<summary>Original prompt</summary>

> Problem
> The MCP server writes plain text to stdout (e.g., "Use Gluestack Components MCP Server running on stdio" and other console.log calls), which corrupts the MCP stdio JSON stream and causes clients like the MCP Inspector to throw a JSON parse error on first connect. We need to ensure stdout is reserved exclusively for the protocol and add CI tests to prevent regressions. Also add a GitHub Actions workflow to run tests on PRs and pushes to main so merges are blocked when tests fail (branch protection can then require this check on main).
> 
> Tasks
> 1) Update index.js so no logging goes to stdout:
>    - Replace all console.log calls with console.error to route logs to stderr.
>    - Locations to change:
>      - After server.connect: console.log("Use Gluestack Components MCP Server running on stdio") -> console.error(...)
>      - In getSelectedComponentsDocs: console.log(`✅ Getting documentation for components: ...`) -> console.error(...)
>      - In the select_components tool handler: console.log(`✅ Selected components: ...`) -> console.error(...)
> 
> 2) Add a test to prevent regressions using Node's built-in test runner:
>    - File: test/no-stdout-on-start.test.js
>    - Behavior: spawn `node index.js`, capture stdout and stderr for ~500ms, and assert that stdout is empty on startup. Kill the process afterward.
> 
> 3) Update package.json scripts to run the tests:
>    - Set "test": "node --test"
>    - Keep existing fields. Ensure type: module remains.
> 
> 4) Add a GitHub Actions workflow to run tests on push to main and on pull requests targeting main:
>    - File: .github/workflows/ci.yml
>    - Use Ubuntu runner, matrix over Node versions [18.x, 20.x, 22.x].
>    - Steps: checkout, setup-node (with cache), npm install, npm test.
>    - Name the workflow "CI" and the job "test" so the status check will be visible as CI/test with matrix expansions.
> 
> Acceptance
> - `npm test` passes locally (no stdout emitted on startup).
> - PR includes the new CI workflow; when the PR is opened, CI should run and pass.
> - After merging, repository owners can enforce branch protection on main to require the CI workflow to pass before merging.
> 
> Implementation details
> - Do not change server behavior besides redirecting logs from stdout to stderr.
> - Do not introduce new dependencies.
> - Preserve ESM (type: module) setup.
> 
> Files to modify/add
> - index.js: change console.log -> console.error in the three locations.
> - package.json: set scripts.test to "node --test".
> - test/no-stdout-on-start.test.js: add the described test.
> - .github/workflows/ci.yml: add the described workflow.
> 
> Please create a branch (e.g., chore/mcp-stdout-ci) off main, commit the changes, and open a pull request titled "Fix MCP stdio logging and add CI test workflow" with a concise description of what changed and how to enable branch protection to block merges on failing tests.


</details>

*This pull request was created as a result of the following prompt from Copilot chat.*

> Problem
> The MCP server writes plain text to stdout (e.g., "Use Gluestack Components MCP Server running on stdio" and other console.log calls), which corrupts the MCP stdio JSON stream and causes clients like the MCP Inspector to throw a JSON parse error on first connect. We need to ensure stdout is reserved exclusively for the protocol and add CI tests to prevent regressions. Also add a GitHub Actions workflow to run tests on PRs and pushes to main so merges are blocked when tests fail (branch protection can then require this check on main).
> 
> Tasks
> 1) Update index.js so no logging goes to stdout:
>    - Replace all console.log calls with console.error to route logs to stderr.
>    - Locations to change:
>      - After server.connect: console.log("Use Gluestack Components MCP Server running on stdio") -> console.error(...)
>      - In getSelectedComponentsDocs: console.log(`✅ Getting documentation for components: ...`) -> console.error(...)
>      - In the select_components tool handler: console.log(`✅ Selected components: ...`) -> console.error(...)
> 
> 2) Add a test to prevent regressions using Node's built-in test runner:
>    - File: test/no-stdout-on-start.test.js
>    - Behavior: spawn `node index.js`, capture stdout and stderr for ~500ms, and assert that stdout is empty on startup. Kill the process afterward.
> 
> 3) Update package.json scripts to run the tests:
>    - Set "test": "node --test"
>    - Keep existing fields. Ensure type: module remains.
> 
> 4) Add a GitHub Actions workflow to run tests on push to main and on pull requests targeting main:
>    - File: .github/workflows/ci.yml
>    - Use Ubuntu runner, matrix over Node versions [18.x, 20.x, 22.x].
>    - Steps: checkout, setup-node (with cache), npm install, npm test.
>    - Name the workflow "CI" and the job "test" so the status check will be visible as CI/test with matrix expansions.
> 
> Acceptance
> - `npm test` passes locally (no stdout emitted on startup).
> - PR includes the new CI workflow; when the PR is opened, CI should run and pass.
> - After merging, repository owners can enforce branch protection on main to require the CI workflow to pass before merging.
> 
> Implementation details
> - Do not change server behavior besides redirecting logs from stdout to stderr.
> - Do not introduce new dependencies.
> - Preserve ESM (type: module) setup.
> 
> Files to modify/add
> - index.js: change console.log -> console.error in the three locations.
> - package.json: set scripts.test to "node --test".
> - test/no-stdout-on-start.test.js: add the described test.
> - .github/workflows/ci.yml: add the described workflow.
> 
> Please create a branch (e.g., chore/mcp-stdout-ci) off main, commit the changes, and open a pull request titled "Fix MCP stdio logging and add CI test workflow" with a concise description of what changed and how to enable branch protection to block merges on failing tests.

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.